### PR TITLE
Removed branch name customization

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"build": "rollup -c",
 		"dev": "rollup -c -w",
 		"start": "sirv public",
-		"deploy": "npm run build && gh-pages -d public -b public"
+		"deploy": "npm run build && gh-pages -d public"
 	},
 	"devDependencies": {
 		"@rollup/plugin-node-resolve": "^8.0.0",


### PR DESCRIPTION
# Summary
The additional parameter `-b` was removed to restore default branch name `gh-pages`.

# Goal
 - Fix bug #7