### PR TITLE
Using relative paths in index.html

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,8 +3,8 @@
 <head>
 	<meta charset='utf-8'>
 	<meta name='viewport' content='width=device-width,initial-scale=1'>
-	<link rel='stylesheet' href='/build/bundle.css'>
-	<script defer src='/build/bundle.js'></script>
+	<link rel='stylesheet' href='build/bundle.css'>
+	<script defer src='build/bundle.js'></script>
 </head>
 <body>
 </body>


### PR DESCRIPTION
# Summary
When used in a deep path, `index.html` was retrieving its components from the root, and the page as not showing.

# Goal
- Fix the _Hello world_ example by using relative paths