### PR TITLE
CD enhancements

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
 		"build": "rollup -c",
 		"dev": "rollup -c -w",
 		"start": "sirv public",
-		"deploy": "npm run build && gh-pages -d public"
+		"deploy": "gh-pages -d public",
+		"build-deploy": "npm run build && npm run deploy"
 	},
 	"devDependencies": {
 		"@rollup/plugin-node-resolve": "^8.0.0",

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+emili.dev


### PR DESCRIPTION
# Summary

The [`CNAME`](https://github.com/emili/labs/blob/master/public/CNAME) file has been checked in to the [`public`](https://github.com/emili/labs/blob/master/public) folder, so it gets automatically copied to the GitHub Pages branch.
In addition, the formerly called `deploy` script has been renamed to `build-deploy` to show its double commitment, and a new simpler `deploy` script is now in charge to call the `gh-pages` routine only.

# Goal
- Automate the deployment process, and provide granularity to the future 'deploy-by-release' pipeline.